### PR TITLE
Make detection work when MWK points to symbolic link.

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ to the top directory of your wiki, MWK is blank or unset)
 endif
 
 # Check if MWK is a directory.
-mwk_dir := $(shell find "$(MWK)" -type d -wholename "$(MWK)")
+mwk_dir := $(shell find -H "$(MWK)" -type d -wholename "$(MWK)")
 ifneq ($(MWK),$(mwk_dir))
 $(error You must set environment variable MWK \
 to the top directory of your wiki, MWK = $(MWK))


### PR DESCRIPTION
If MWK is a symbolic link, then the detection of the directory fails at line 19. Added -H option to `find` so that it follows symbolic directories.